### PR TITLE
Page source Url without fragment

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,11 +44,14 @@
     }
     const name = getMediaTitle(node)
 
+    const pageSrcUrl = new URL(window.location.href)
+    pageSrcUrl.hash = ''
+
     if (src && src !== '') {
       return [{
         'name': name,
         'src': src,
-        'pageSrc': window.location.href,
+        'pageSrc': pageSrcUrl.href,
         'pageTitle': document.title,
         'mimeType': mimeType,
         'duration': getMediaDurationInSeconds(node),
@@ -63,7 +66,7 @@
             sources.push({
               'name': name,
               'src': fixUpRelativeUrl(node.src),
-              'pageSrc': window.location.href,
+              'pageSrc': pageSrcUrl.href,
               'pageTitle': document.title,
               'mimeType': mimeType,
               'duration': getMediaDurationInSeconds(target),
@@ -75,7 +78,7 @@
             sources.push({
               'name': name,
               'src': fixUpRelativeUrl(node.src),
-              'pageSrc': window.location.href,
+              'pageSrc': pageSrcUrl.href,
               'pageTitle': document.title,
               'mimeType': mimeType,
               'duration': getMediaDurationInSeconds(target),


### PR DESCRIPTION
The playlist feature currently treats URLs with and without fragments differently, but I've made changes to treat them the same.

Before changes:

[Screencast from 15-08-23 06:53:49 PM IST.webm](https://github.com/brave/playlist-component/assets/67573527/a2e31603-e0b6-409c-84f5-763e67ec8543)

After changes:

[Screencast from 15-08-23 06:55:01 PM IST.webm](https://github.com/brave/playlist-component/assets/67573527/b45376c3-4121-4443-bbfc-e4be5db14f4b)

Related PR in `brave core` repo:

https://github.com/brave/brave-core/pull/19695
