### PR TITLE
Allow only https:// scheme

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@
     if (!isHttpsScheme(url)) {
       return null
     }
-    
+
     if (!url.startsWith('https://')) {
       // Fix up relative path to absolute path
       url = new URL(url, window.location.origin).href
@@ -60,7 +60,7 @@
     }
     const name = getMediaTitle(node)
 
-    if (src && src !== '') {
+    if (src) {
       return [{
         'name': name,
         src,
@@ -75,7 +75,7 @@
       const sources = []
       document.querySelectorAll('source').forEach(function (node) {
         const src = fixUpUrl(node.src)
-        if (src && src !== '') {
+        if (src) {
           if (node.closest('video') === target) {
             sources.push({
               'name': name,


### PR DESCRIPTION
issue : https://github.com/brave/brave-browser/issues/33647

Currently, we allow media with http:// scheme to be added. But From the security point of view, it'd be better to allow only https:// scheme.

This change will be tested by brave_browser_tests in brave-core : https://github.com/brave/brave-core/pull/20534