### PR TITLE
Add 'srcIsMediaSourceObjectURL' for media src blob url

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,8 +33,8 @@ medias = (async function () {
     return Promise.any([
       new Promise(resolve => {
         fetch(src, { signal })
-          .then(() => false)
-          .catch(() => true)
+          .then(() => resolve(false))
+          .catch(() => resolve(true))
       }),
       maybeAbortFetch
     ])

--- a/index.js
+++ b/index.js
@@ -22,20 +22,15 @@ medias = (async function () {
 
     const controller = new AbortController()
     const signal = controller.signal
-    let timeout
     const maybeAbortFetch = new Promise(resolve =>
-      timeout = setTimeout(() => {
+      setTimeout(() => {
         resolve(false)
         controller.abort()
       }, 500)
     )
 
     return Promise.any([
-      new Promise(resolve => {
-        fetch(src, { signal })
-          .then(() => resolve(false))
-          .catch(() => resolve(true))
-      }),
+      fetch(src, { signal }).then(() => false).catch(() => true),
       maybeAbortFetch
     ])
   }

--- a/index.js
+++ b/index.js
@@ -52,6 +52,8 @@ medias = (async function () {
 
     if (url.startsWith('blob:')) {
       url = url.substring(5)
+      // blob: should be absolute path.
+      return url.startsWith('https://')
     }
 
     let isHttpsScheme = false
@@ -85,16 +87,7 @@ medias = (async function () {
   }
 
   /**
-   * MediaItem will be parsed into C++ object representing PlaylistItem in
-   *       {
-        "detected": boolean,
-        "mimeType": "video" | "audio",
-        "name": string,
-        "pageSrc": url,
-        "pageTitle": string
-        "src": url
-        "thumbnail": url | undefined
-      }
+   * MediaItem will be parsed into C++ object representing PlaylistItem
    * @typedef MediaItem
    * @type {object}
    * @property {string} name
@@ -233,8 +226,8 @@ medias = (async function () {
     return clampDuration(duration)
   }
 
-  const videoElements = document.querySelectorAll('video') ?? []
-  const audioElements = document.querySelectorAll('audio') ?? []
+  const videoElements = document.querySelectorAll('video')
+  const audioElements = document.querySelectorAll('audio')
   // TODO(sko) These data could be incorrect when there're multiple items.
   // For now we're assuming that the first media is a representative one.
   const thumbnail = getThumbnail()


### PR DESCRIPTION
This change is part of https://github.com/brave/brave-core/pull/21332.
Makes this detection script recognize `blob:` urls pointing at `MediaSource` object.